### PR TITLE
Convert class names always to lowercase

### DIFF
--- a/src/extras/moose/famix_repository.ts
+++ b/src/extras/moose/famix_repository.ts
@@ -20,7 +20,7 @@ export class FamixRepository {
       }
     }
     const newClass = new Class(this);
-    newClass.setName(name);
+    newClass.setName(name.toLowerCase());
     newClass.setIsStub(true);
     if ((isInterface) && (isInterface === true)) {
       newClass.setIsInterface(true);


### PR DESCRIPTION
The conversion to lowercase was missed for class names. 
I made a file compare with notepad++ for the mse files of the SAP2Moose project before and after this change and found that only classnames changed to lowercase.
I propose that you leave the conversion to lowercase. And I think about extracting ABAP names in the SAP2Moose project also with lowercase.